### PR TITLE
Support for Docker and Singularity containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get upgrade -y && apt-get clean
+
+RUN apt-get install -y curl python3 python3-dev python3-distutils python3-pip git wget
+
+RUN pip3 install astropy pysynphot scipy numpy matplotlib 
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN export PYTHONPATH=$PYTHONPATH:/SPISEA
+
+RUN cd / && git clone https://github.com/astropy/SPISEA.git
+
+ENV PYTHONPATH "${PYTHONPATH}:/SPISEA/"
+	
+# Add data to cdbs folder
+RUN mkdir /cdbs
+WORKDIR /cdbs 
+RUN wget https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar 
+RUN wget https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_star-galaxy-models_multi_v3_synphot2.tar 
+RUN tar -xvf hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar && rm hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar
+RUN tar -xvf hlsp_reference-atlases_hst_multi_star-galaxy-models_multi_v3_synphot2.tar && rm hlsp_reference-atlases_hst_multi_star-galaxy-models_multi_v3_synphot2.tar
+
+# Move data folders to cdbs
+RUN mv /cdbs/grp/redcat/trds/comp /cdbs
+RUN mv /cdbs/grp/redcat/trds/mtab /cdbs
+RUN mv /cdbs/grp/redcat/trds/grid /cdbs
+
+RUN mkdir /cdbs/models
+WORKDIR /cdbs/models
+RUN wget http://astro.berkeley.edu/~jlu/spisea/spisea_models.tar.gz && wget http://astro.berkeley.edu/~jlu/spisea/spisea_cdbs.tar.gz
+RUN tar -xvf spisea_cdbs.tar.gz && tar -xvf spisea_models.tar.gz && rm spisea_cdbs.tar.gz && rm spisea_models.tar.gz
+
+ENV PYSYN_CDBS /cdbs/models/cdbs/
+ENV SPISEA_MODELS /cdbs/models
+
+
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -225,7 +225,7 @@ To execute a script you have in your current folder::
 Deploy from DockerHub
 ==========================
 
-If you don't want to build the image from scratch you can use a pre-build container image from `DockerHub <https://hub.docker.com/r/amigahub/spisea>` using the following commands::
+If you don't want to build the image from scratch you can use a pre-build container image from `DockerHub <https://hub.docker.com/r/amigahub/spisea>`_ using the following commands::
 
     docker pull amigahub/spisea:v1
 
@@ -238,7 +238,7 @@ To execute a script you have in your current folder::
     docker run -ti -v $PWD:/scripts/ amigahub/spisea:v1 python /scripts/myscript.py
 
 ==========================
-Deploy from Singularity Containers
+Deploy from Singularity containers
 ==========================
 
 Download the image from DockerHub and convert it into a ``.sif`` image for Singularity.::

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -189,4 +189,69 @@ either or both of the following warnings::
     UserWarning: PYSYN_CDBS is undefined; functionality will be SEVERELY crippled.
     
     UserWarning: SPISEA_MODELS is undefined; functionality will be SEVERELY crippled.
+      
+==========================
+Build and deploy from Docker
+==========================
+
+Build your own SPISEA image for Docker Containers. This installation form contains SPISEA deployed in a container and includes the data sets, models and all the necessary paths and code.
+
+Requirements
+-----------------------
+
+- Linux, Windows or MacOS with Docker installed.
+- At least 2 CPUs and 4 GB of RAM and 16 GB of storage.
+
+Installation
+-----------------------
+
+To create the container image, clone this repository and build the container:
+
+    git clone https://github.com/astropy/SPISEA.git
+    cd SPISEA
+    docker build -t spisea .
     
+Usage
+-----------------------
+To open a shell ready play with SPISEA:
+
+    docker run -ti spisea bash
+
+To execute a script you have in your current folder: 
+
+    docker run -ti -v $PWD:/scripts/ spisea python /scripts/myscript.py
+
+==========================
+Deploy from DockerHub
+==========================
+
+If you don't want to build the image from scratch you can use a pre-build container image from `DockerHub <https://hub.docker.com/r/amigahub/spisea>` using the following commands:
+
+    docker pull amigahub/spisea:v1
+
+Then, to open a shell ready to play with SPISEA:
+
+    docker run -ti amigahub/spisea:v1 bash
+
+To execute a script you have in your current folder: 
+
+    docker run -ti -v $PWD:/scripts/ amigahub/spisea:v1 python /scripts/myscript.py
+
+==========================
+Deploy from Singularity Containers
+==========================
+
+Download the image from DockerHub and convert it into a ``.sif`` image for Singularity.
+
+    singularity pull spisea.sif docker://amigahub/spisea:v1
+    
+After downloading the image, you can use it in singularity by opening a shell on SPISEA image:
+
+    singularity shell spisea.sif 
+
+
+
+
+
+    
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -205,7 +205,7 @@ Requirements
 Installation
 -----------------------
 
-To create the container image, clone this repository and build the container:
+To create the container image, clone this repository and build the container::
 
     git clone https://github.com/astropy/SPISEA.git
     cd SPISEA
@@ -213,11 +213,11 @@ To create the container image, clone this repository and build the container:
     
 Usage
 -----------------------
-To open a shell ready play with SPISEA:
+To open a shell ready play with SPISEA::
 
     docker run -ti spisea bash
 
-To execute a script you have in your current folder: 
+To execute a script you have in your current folder:: 
 
     docker run -ti -v $PWD:/scripts/ spisea python /scripts/myscript.py
 
@@ -225,15 +225,15 @@ To execute a script you have in your current folder:
 Deploy from DockerHub
 ==========================
 
-If you don't want to build the image from scratch you can use a pre-build container image from `DockerHub <https://hub.docker.com/r/amigahub/spisea>` using the following commands:
+If you don't want to build the image from scratch you can use a pre-build container image from `DockerHub <https://hub.docker.com/r/amigahub/spisea>` using the following commands::
 
     docker pull amigahub/spisea:v1
 
-Then, to open a shell ready to play with SPISEA:
+Then, to open a shell ready to play with SPISEA::
 
     docker run -ti amigahub/spisea:v1 bash
 
-To execute a script you have in your current folder: 
+To execute a script you have in your current folder::
 
     docker run -ti -v $PWD:/scripts/ amigahub/spisea:v1 python /scripts/myscript.py
 
@@ -241,11 +241,11 @@ To execute a script you have in your current folder:
 Deploy from Singularity Containers
 ==========================
 
-Download the image from DockerHub and convert it into a ``.sif`` image for Singularity.
+Download the image from DockerHub and convert it into a ``.sif`` image for Singularity.::
 
     singularity pull spisea.sif docker://amigahub/spisea:v1
     
-After downloading the image, you can use it in singularity by opening a shell on SPISEA image:
+After downloading the image, you can use it in singularity by opening a shell on SPISEA image::
 
     singularity shell spisea.sif 
 


### PR DESCRIPTION
Hi! we needed to containerize SPISEA for a workshop (working with Kubernetes) and we have created the Dockerfile to deploy SPISEA completely from docker containers.  We also took the opportunity to use it from Singularity. I leave you in this PR the Dockerfile, which provides the steps to set up SPISEA and the documentation to a) build the image from Dockerfile, b) download it from DockerHub to use it and c) use SPISEA from Singularity.
If you find this interesting, you can include it. Thank you very much.
