### PR TITLE
Search fix: improves how SPISEA selects models from grid

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,9 +25,9 @@ copyright = '2020, Matthew Hosek Jr, Jessica R. Lu, Casey Y. Lam.'
 author = 'Matthew Hosek Jr, Jessica R. Lu, Casey Y. Lam'
 
 # The short X.Y version
-version = '2.1.5'
+version = '2.1.6'
 # The full version, including alpha/beta/rc tags
-release = '2.1.5'
+release = '2.1.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Change Log
     model to pull from the grid of available models. Previously, it used
     first grid model where grid model value >
     requested value (numpy.searchsorted routine). Now, is takes grid model
-    where the difference betwen the grid model value and requested
+    where the difference between the grid model value and requested
     value is minimized. This is most relevant for metallicity
     selection for MIST isochrones, where the model grid metallicities are
     spaced out. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,16 @@ releases will be co-authors in future SPISEA software papers.
 
 Change Log
 ----------
+2.1.6 (2022-09-15)
+  * Bugfix in how evolution object identifies what age and metallicity
+    model to pull from the grid of available models. Previously, it used
+    first grid model where grid model value >
+    requested value (numpy.searchsorted routine). Now, is takes grid model
+    where the difference betwen the grid model value and requested
+    value is minimized. This is most relevant for metallicity
+    selection for MIST isochrones, where the model grid metallicities are
+    spaced out. 
+
 2.1.5 (2022-07-20)
   * Added additional parameters to get_bb_atmosphere function to give
     user control over the min and max wavelength values, as well as

--- a/spisea/evolution.py
+++ b/spisea/evolution.py
@@ -1,6 +1,6 @@
 import math
 import logging
-from numpy import searchsorted, genfromtxt
+from numpy import genfromtxt
 import numpy as np
 import os
 import glob
@@ -137,11 +137,13 @@ class Geneva(StellarEvolution):
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
         
         # convert age (in yrs) to log scale and find nearest value in grid
-        age_idx = searchsorted(self.age_list, math.log10(age), side='right')
+        log_age = np.log10(age)
+
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_' + str(self.age_list[age_idx]) + '.fits'
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
         
         # generate isochrone file string
@@ -210,14 +212,11 @@ class Ekstrom12(StellarEvolution):
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
         
         # Find nearest age in grid to input grid
-        if log_age != self.age_list[0]:
-            age_idx = searchsorted(self.age_list, log_age, side='right')
-        else:
-            age_idx = searchsorted(self.age_list, log_age, side='left')
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
         
         # generate isochrone file string
@@ -444,14 +443,11 @@ class Parsec(StellarEvolution):
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
         
         # Find nearest age in grid to input grid
-        if log_age != self.age_list[0]:
-            age_idx = searchsorted(self.age_list, log_age, side='right')
-        else:
-            age_idx = searchsorted(self.age_list, log_age, side='left')
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
         
         # generate isochrone file string
@@ -594,14 +590,11 @@ class Pisa(StellarEvolution):
             logger.error('Requested metallicity {0} is out of bounds for evolution model. Available z-vals: {1}.'.format(z_defined, self.z_list))
         
         # Find nearest age in grid to input grid
-        if log_age != self.age_list[0]:
-            age_idx = searchsorted(self.age_list, log_age, side='right')
-        else:
-            age_idx = searchsorted(self.age_list, log_age, side='left')
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
         
         # generate isochrone file string
@@ -756,14 +749,11 @@ class Baraffe15(StellarEvolution):
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
         
         # Find nearest age in grid to input grid
-        if log_age != self.age_list[0]:
-            age_idx = searchsorted(self.age_list, log_age, side='right')
-        else:
-            age_idx = searchsorted(self.age_list, log_age, side='left')
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
         
         # generate isochrone file string
@@ -1096,18 +1086,13 @@ class MISTv1(StellarEvolution):
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
 
         # Find nearest age in grid to input grid
-        if log_age != self.age_list[0]:
-            age_idx = searchsorted(self.age_list, log_age, side='right')
-        else:
-            age_idx = searchsorted(self.age_list, log_age, side='left')
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
-        if z_idx == len(self.z_list):   # in case just over last index
-            z_idx = z_idx - 1
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
-        
+            
         # generate isochrone file string
         full_iso_file = self.model_dir + 'iso/' + z_dir + iso_file
         
@@ -1292,13 +1277,13 @@ class MergedBaraffePisaEkstromParsec(StellarEvolution):
         if ((z_defined < np.min(self.z_list)) or
                 (z_defined > np.max(self.z_list))):
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
-        
-        # convert age (in yrs) to log scale and find nearest value in grid
-        age_idx = searchsorted(self.age_list, log_age, side='right')
+
+        # Find nearest age in grid to input grid
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
 
         # generate isochrone file string
@@ -1384,12 +1369,12 @@ class MergedPisaEkstromParsec(StellarEvolution):
         if not z_defined in self.z_list:
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
         
-        # convert age (in yrs) to log scale and find nearest value in grid
-        age_idx = searchsorted(self.age_list, log_age, side='right')
+        # Find nearest age in grid to input grid
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
         iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
 
         # generate isochrone file string
@@ -1495,12 +1480,12 @@ class MergedSiessGenevaPadova(StellarEvolution):
         if not z_defined in self.z_list:
             logger.error('Requested metallicity {0} is out of bounds.'.format(z_defined))
         
-        # convert age (in yrs) to log scale and find nearest value in grid
-        age_idx = searchsorted(self.age_list, log_age, side='right')
-        iso_file = 'iso_{0:.2f}.dat'.format(self.age_list[age_idx])
+        # Find nearest age in grid to input grid
+        age_idx = np.where(abs(np.array(self.age_list) - log_age) == min(abs(np.array(self.age_list) - log_age)) )[0][0]
+        iso_file = 'iso_{0:.2f}.fits'.format(self.age_list[age_idx])
         
         # find closest metallicity value
-        z_idx = searchsorted(self.z_list, z_defined, side='left')
+        z_idx = np.where(abs(np.array(self.z_list) - z_defined) == min(abs(np.array(self.z_list) - z_defined)) )[0][0]
         z_dir = self.z_file_map[self.z_list[z_idx]]
 
         # generate isochrone file string

--- a/spisea/tests/test_models.py
+++ b/spisea/tests/test_models.py
@@ -1,4 +1,5 @@
 # Test functions for the different stellar evolution and atmosphere models
+import numpy as np
 import pdb
 
 def test_evo_model_grid_num():
@@ -54,6 +55,16 @@ def test_evolution_models():
             for kk in age_vals[ii]:
                 try:
                     test = evo.isochrone(age=10**kk, metallicity=jj)
+
+                    # Make sure the actual isochrone metallicity taken is
+                    # indeed the closest to the desired metallicity (e.g., closest point
+                    # in evo grid)
+                    z_ratio = np.log10(np.array(evo.z_list) / evo.z_solar)
+                    closest_idx = np.where( abs(z_ratio - jj) == min(abs(z_ratio - jj)) )[0][0]
+                    expected_val = z_ratio[closest_idx]
+
+                    assert np.isclose(test.meta['metallicity_act'], expected_val, atol=0.01)
+
                 except:
                     raise Exception('EVO TEST FAILED: {0}, age = {1}, metal = {2}'.format(evo, kk, jj))
 


### PR DESCRIPTION
Previously, SPISEA used first grid model where grid model value > requested value (numpy.searchsorted routine). Now, SPISEA takes the grid model where the difference between the grid model value and requested value is minimized. This is most relevant for metallicity selection for MIST isochrones, where the model grid metallicities are spaced out. Also added code to test function to make sure this is working.